### PR TITLE
feat: afficher le salaire majoré dans le récap mensuel

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -516,6 +516,9 @@ const App = () => {
     ? contractDailyHours * workDays
     : 0;
   const hoursDelta = totalHours - theoreticalWeeklyHours;
+  const hourlyRate = Number(settings?.tarifHoraire) || 0;
+  const majorationRate = Number(settings?.tarifMajoration) || 0;
+  const majoredSalary = hoursDelta > 0 ? hoursDelta * hourlyRate * majorationRate : 0;
   const workedWeeks = monthlyStats && daysPerWeek > 0 ? workDays / daysPerWeek : 0;
   const meanHoursPerWeek = workedWeeks > 0 ? totalHours / workedWeeks : 0;
   const meanHoursPerDay = Number(monthlyStats?.meanHoursPerDay) || 0;
@@ -792,6 +795,10 @@ const App = () => {
                       <span className="font-medium">
                         {(Number(monthlyStats?.anneeComplete?.salaireNetMensualise) || 0).toFixed(2)}€
                       </span>
+                    </div>
+                    <div className="flex justify-between">
+                      <span className="text-gray-600">Salaire majoré:</span>
+                      <span className="font-medium">{majoredSalary.toFixed(2)}€</span>
                     </div>
                     <div className="flex justify-between">
                       <span className="text-gray-600">Frais repas:</span>


### PR DESCRIPTION
## Summary
- calcule le salaire majoré à partir de l'écart positif, du taux horaire et du taux de majoration
- affiche ce montant dans la section Récapitulatif mensuel sous le salaire mensualisé

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68d8567dda8c832194196b8ddc014463